### PR TITLE
Remove manual setting of the AnovaNanoSwitch attribute name and ID.

### DIFF
--- a/custom_components/anova_nano/switch.py
+++ b/custom_components/anova_nano/switch.py
@@ -40,8 +40,6 @@ class AnovaNanoSwitch(AnovaNanoDescriptionEntity, SwitchEntity):
     ):
         """Initialize the switch."""
         super().__init__(coordinator, description=entity_description)
-        self._attr_name = "Cooking"
-        self._attr_unique_id = "switch"
         self.entity_description = entity_description
         self.coordinator: AnovaNanoDataUpdateCoordinator = coordinator
 


### PR DESCRIPTION
The name is already set by the description and the ID should be dynamically generated by the base SwitchEntity class. I've tested this update with my own HA instance, and it works correctly.

There is a major caveat: this breaks any existing Cooking switches because HA will regenerate those entity IDs and create a new entity. Any devices added before this update will see a second Cooking switch. This can be fixed by deleting the old entity and giving the new entity the name of the old switch to fix any dashboards or automations.